### PR TITLE
Dev env setup + unify selection/share highlight to yellow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is a personal blog built with the [Zola](https://www.getzola.org/) static site generator (theme: Seje2). There is no Node/Python project; the only build tool is the `zola` binary.
+
+- **Zola version:** Use Zola `0.17.1` (matches the `shalzz/zola-deploy-action@v0.17.1` used in `.github/workflows/build.yml`). Newer Zola (0.19+) renamed `config.toml` fields (e.g. `highlight_code` → `highlighting`) and will fail to build this repo's `config.toml`. The update script installs `0.17.1` if `zola` is missing.
+- **Build:** `zola build` (output goes to `/public`, which is gitignored).
+- **Check/lint:** `zola check`. Note it validates *external* links over the network, so it will report many false-positive broken links (403/404/cert errors from third-party sites) that are unrelated to the repo. Internal link checks are the meaningful signal.
+- **Run (dev):** `zola serve --interface 0.0.0.0 --port 1111`. Serves at `http://localhost:1111/` with live reload; new/edited files in `content/` are picked up automatically.
+- **Content:** Posts live in `content/*.md` with TOML front matter (`+++ ... +++`). Most content is in Chinese; `default_language = "zh-cn"`.
+- **Deploy:** Handled by the GitHub Action (manual `workflow_dispatch`) to the `gh-pages` branch; no local deploy needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `AGENTS.md` with `## Cursor Cloud specific instructions` (Zola version pin `0.17.1`, build/check/serve commands).
- Unifies highlight colors: the text-selection highlight and the shared text-fragment (`::target-text`) highlight are now both the same yellow (`--selection: #ffe066`), replacing the previous green selection.

## Changes

- `sass/style.scss`: change `--selection` from `#dbe8b3` (green) to `#ffe066` (yellow); add a `::target-text` rule using the same `--selection` variable so shared-link highlights match the selection highlight exactly.

## Verification

- `zola build` → 30 pages + 2 sections, Sass compiles cleanly.
- Selection highlight renders yellow with the "Share" button.
- Opening a shared text-fragment link (`#:~:text=...`) on a fresh load highlights the matched text in the same yellow.

[shared_link_yellow_highlight_fresh_load.mp4](https://cursor.com/agents/bc-e280e379-91d3-47ed-ab5b-bdd06e044567/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshared_link_yellow_highlight_fresh_load.mp4)

[Text selection highlighted in yellow with Share button](https://cursor.com/agents/bc-e280e379-91d3-47ed-ab5b-bdd06e044567/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyellow_selection_highlight.webp)
[Shared text-fragment link highlighted in the same yellow](https://cursor.com/agents/bc-e280e379-91d3-47ed-ab5b-bdd06e044567/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyellow_share_highlight_clean.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e280e379-91d3-47ed-ab5b-bdd06e044567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e280e379-91d3-47ed-ab5b-bdd06e044567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

